### PR TITLE
docs(auto-drive): document automatic MEMORY.md pinning behavior

### DIFF
--- a/autonomys/auto-drive/SKILL.md
+++ b/autonomys/auto-drive/SKILL.md
@@ -167,6 +167,7 @@ If the agent's server dies, a new instance only needs the last CID to walk the e
 - The free API key has a **20 MB per month upload limit** on mainnet. Downloads are unlimited. Check remaining credits via `GET /subscriptions/credits`.
 - An API key is required for uploads, memory saves, and chain recall. General file downloads work without one via the public gateway, but compressed files will not be decompressed.
 - The memory state file tracks `lastCid`, `lastUploadTimestamp`, and `chainLength`. Back up the `lastCid` value — it's your resurrection key.
+- The `autodrive-save-memory.sh` script **automatically pins the latest CID to `MEMORY.md`** if the file exists in the workspace. It creates an `## Auto-Drive Chain` section and updates it on each save. You do not need to track the latest CID in MEMORY.md manually — the script handles this.
 - Files are uploaded in a single chunk. The free tier's 20 MB/month limit is effectively a per-file ceiling — keep individual uploads well under that to preserve your monthly budget.
 - Gateway URL for any file: `https://gateway.autonomys.xyz/file/<CID>`
 - For true resurrection resilience, consider anchoring the latest CID on-chain via the Autonomys EVM — this makes recovery possible without keeping track of the head CID yourself. See [openclaw-memory-chain](https://github.com/autojeremy/openclaw-memory-chain) for an example contract implementation.


### PR DESCRIPTION
## What

Adds a note to the Auto Drive SKILL.md documenting that `autodrive-save-memory.sh` automatically pins the latest CID to `MEMORY.md`.

## Why

Without this note, agents manually track the latest CID in MEMORY.md and end up with duplicate entries. I hit this myself today — the script created an `## Auto-Drive Chain` section, and I had already added one manually.

One-line addition to the Important Notes section.