### PR TITLE
fix: write mnemonic to dead-drop file instead of stderr

### DIFF
--- a/autonomys/auto-respawn/SKILL.md
+++ b/autonomys/auto-respawn/SKILL.md
@@ -99,7 +99,14 @@ This generates a 12-word recovery phrase and derives both addresses:
 - **Consensus address** (`su...`) — for the base chain (balances, transfers, remarks)
 - **EVM address** (`0x...`) — for Auto-EVM smart contracts (anchor, gethead)
 
-⚠️ The recovery phrase is displayed **once**. Remind the user to save it immediately.
+The recovery phrase is written to a dead-drop file at `~/.openclaw/auto-respawn/.last-mnemonic` with `chmod 000` (no permissions). The agent **must never read this file**. Tell the user to retrieve it manually:
+
+```bash
+chmod 600 ~/.openclaw/auto-respawn/.last-mnemonic
+cat ~/.openclaw/auto-respawn/.last-mnemonic
+# Back it up securely, then delete it:
+rm ~/.openclaw/auto-respawn/.last-mnemonic
+```
 
 ### 2. Fund the Wallet
 
@@ -173,6 +180,7 @@ This skill stores data under `~/.openclaw/auto-respawn/`:
 
 - **`wallets/<name>.json`** — encrypted wallet keyfiles (consensus + EVM keys). Directory created with mode `0700`, files with mode `0600`.
 - **`.passphrase`** — optional passphrase file (mode `0600`). Used automatically when present.
+- **`.last-mnemonic`** — dead-drop recovery phrase file (mode `0000`). Created by `wallet create`, readable only after the human operator runs `chmod 600` on it. **Agents must never access this file.** The user should back it up and delete it promptly.
 
 No data is stored outside this directory.
 
@@ -211,7 +219,7 @@ Override with `AUTO_RESPAWN_CONTRACT_ADDRESS` if you deploy your own contract.
 npx tsx auto-respawn.ts wallet create [--name <name>] [--passphrase <passphrase>]
 ```
 
-Creates a new wallet with an encrypted keyfile. Derives both a consensus (`su...`) and EVM (`0x...`) address from the same mnemonic. The 12-word recovery phrase is displayed **once** — the user must back it up immediately. Default wallet name is `default`.
+Creates a new wallet with an encrypted keyfile. Derives both a consensus (`su...`) and EVM (`0x...`) address from the same mnemonic. The 12-word recovery phrase is saved to a dead-drop file (`~/.openclaw/auto-respawn/.last-mnemonic`) with no read permissions — the user must retrieve it manually. Default wallet name is `default`.
 
 ### Import a Wallet
 
@@ -329,7 +337,7 @@ You can pass either an EVM address (`0x...`) or a wallet name. If you pass a wal
 
 **User:** "Create a wallet for my agent"
 → Run `npx tsx auto-respawn.ts wallet create --name my-agent`
-→ Show the user both addresses. Remind them to back up the recovery phrase.
+→ Show the user both addresses. Tell them to retrieve the recovery phrase from the dead-drop file and back it up securely.
 
 **User:** "What are my addresses?"
 → Run `npx tsx auto-respawn.ts wallet info --name my-agent`
@@ -371,7 +379,7 @@ You can pass either an EVM address (`0x...`) or a wallet name. If you pass a wal
 
 ## Important Notes
 
-- **Never log, store, or transmit recovery phrases or passphrases.** The recovery phrase is shown once at wallet creation for the user to back up. Never reference it again.
+- **Never read, log, store, or transmit recovery phrases or passphrases.** The recovery phrase is saved to `~/.openclaw/auto-respawn/.last-mnemonic` at wallet creation — **never attempt to read, cat, chmod, or access this file**. It exists solely for the human operator to retrieve manually.
 - **Always confirm transfers and anchor operations with the user before executing.** Tokens have real value on mainnet.
 - **Mainnet operations produce warnings** in the output. Exercise extra caution with real AI3 tokens.
 - Wallet keyfiles are stored at `~/.openclaw/auto-respawn/wallets/` — encrypted with the user's passphrase. The EVM private key is stored encrypted alongside the consensus keypair.

--- a/autonomys/auto-respawn/SKILL.md
+++ b/autonomys/auto-respawn/SKILL.md
@@ -99,13 +99,13 @@ This generates a 12-word recovery phrase and derives both addresses:
 - **Consensus address** (`su...`) — for the base chain (balances, transfers, remarks)
 - **EVM address** (`0x...`) — for Auto-EVM smart contracts (anchor, gethead)
 
-The recovery phrase is written to a dead-drop file at `~/.openclaw/auto-respawn/.last-mnemonic` with `chmod 000` (no permissions). The agent **must never read this file**. Tell the user to retrieve it manually:
+The recovery phrase is written to a dead-drop file at `~/.openclaw/auto-respawn/.mnemonic-<name>` with `chmod 000` (no permissions). The agent **must never read this file**. Tell the user to retrieve it manually:
 
 ```bash
-chmod 600 ~/.openclaw/auto-respawn/.last-mnemonic
-cat ~/.openclaw/auto-respawn/.last-mnemonic
+chmod 600 ~/.openclaw/auto-respawn/.mnemonic-my-agent
+cat ~/.openclaw/auto-respawn/.mnemonic-my-agent
 # Back it up securely, then delete it:
-rm ~/.openclaw/auto-respawn/.last-mnemonic
+rm ~/.openclaw/auto-respawn/.mnemonic-my-agent
 ```
 
 ### 2. Fund the Wallet
@@ -180,7 +180,7 @@ This skill stores data under `~/.openclaw/auto-respawn/`:
 
 - **`wallets/<name>.json`** — encrypted wallet keyfiles (consensus + EVM keys). Directory created with mode `0700`, files with mode `0600`.
 - **`.passphrase`** — optional passphrase file (mode `0600`). Used automatically when present.
-- **`.last-mnemonic`** — dead-drop recovery phrase file (mode `0000`). Created by `wallet create`, readable only after the human operator runs `chmod 600` on it. **Agents must never access this file.** The user should back it up and delete it promptly.
+- **`.mnemonic-<name>`** — dead-drop recovery phrase file (mode `0000`), one per wallet. Created by `wallet create`, readable only after the human operator runs `chmod 600` on it. **Agents must never access these files.** The user should back up and delete each one promptly.
 
 No data is stored outside this directory.
 
@@ -219,7 +219,7 @@ Override with `AUTO_RESPAWN_CONTRACT_ADDRESS` if you deploy your own contract.
 npx tsx auto-respawn.ts wallet create [--name <name>] [--passphrase <passphrase>]
 ```
 
-Creates a new wallet with an encrypted keyfile. Derives both a consensus (`su...`) and EVM (`0x...`) address from the same mnemonic. The 12-word recovery phrase is saved to a dead-drop file (`~/.openclaw/auto-respawn/.last-mnemonic`) with no read permissions — the user must retrieve it manually. Default wallet name is `default`.
+Creates a new wallet with an encrypted keyfile. Derives both a consensus (`su...`) and EVM (`0x...`) address from the same mnemonic. The 12-word recovery phrase is saved to a dead-drop file (`~/.openclaw/auto-respawn/.mnemonic-<name>`) with no read permissions — the user must retrieve it manually. Default wallet name is `default`.
 
 ### Import a Wallet
 
@@ -379,7 +379,7 @@ You can pass either an EVM address (`0x...`) or a wallet name. If you pass a wal
 
 ## Important Notes
 
-- **Never read, log, store, or transmit recovery phrases or passphrases.** The recovery phrase is saved to `~/.openclaw/auto-respawn/.last-mnemonic` at wallet creation — **never attempt to read, cat, chmod, or access this file**. It exists solely for the human operator to retrieve manually.
+- **Never read, log, store, or transmit recovery phrases or passphrases.** The recovery phrase is saved to `~/.openclaw/auto-respawn/.mnemonic-<name>` at wallet creation — **never attempt to read, cat, chmod, or access these files**. They exist solely for the human operator to retrieve manually.
 - **Always confirm transfers and anchor operations with the user before executing.** Tokens have real value on mainnet.
 - **Mainnet operations produce warnings** in the output. Exercise extra caution with real AI3 tokens.
 - Wallet keyfiles are stored at `~/.openclaw/auto-respawn/wallets/` — encrypted with the user's passphrase. The EVM private key is stored encrypted alongside the consensus keypair.

--- a/autonomys/auto-respawn/auto-respawn.ts
+++ b/autonomys/auto-respawn/auto-respawn.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { connectApi, disconnectApi, disconnectEvmProvider, resolveNetwork, isMainnet } from './lib/network.js'
-import { createWallet, importWallet, listWallets, loadWallet, getWalletInfo, loadEvmAddress, loadEvmPrivateKey } from './lib/wallet.js'
+import { createWallet, importWallet, listWallets, loadWallet, getWalletInfo, loadEvmAddress, loadEvmPrivateKey, writeMnemonicDeadDrop } from './lib/wallet.js'
 import { queryBalance } from './lib/balance.js'
 import { queryEvmBalance } from './lib/evm-balance.js'
 import { transferTokens } from './lib/transfer.js'
@@ -39,23 +39,16 @@ async function handleWallet(subcommand: string | undefined, flags: Record<string
     case 'create': {
       const name = flags.name || 'default'
       const result = await createWallet(name, flags.passphrase)
-      // Output mnemonic to stderr so it's visible to the user but separable from JSON output
-      console.error('')
-      console.error('=== IMPORTANT: BACKUP YOUR RECOVERY PHRASE ===')
-      console.error('')
-      console.error(`  ${result.mnemonic}`)
-      console.error('')
-      console.error('Write these 12 words down and store them securely.')
-      console.error('This is the ONLY time they will be displayed.')
-      console.error('Anyone with these words can access your wallet.')
-      console.error('')
-      console.error('===============================================')
-      console.error('')
+      // Write mnemonic to a dead-drop file (chmod 000) instead of stderr.
+      // The agent never sees the phrase — only the file path appears in output.
+      const mnemonicPath = await writeMnemonicDeadDrop(result.mnemonic)
       output({
         name: result.name,
         address: result.address,
         evmAddress: result.evmAddress,
         keyfilePath: result.keyfilePath,
+        mnemonicPath,
+        message: 'IMPORTANT: Your recovery phrase controls this wallet. It has been saved to the file shown in mnemonicPath. To retrieve it: chmod 600 <path> && cat <path> — back it up securely offline, then delete the file. Anyone with these 12 words has full access to your funds.',
       })
       break
     }


### PR DESCRIPTION
## Summary
- Replaces stderr mnemonic output in `wallet create` with a chmod-000 dead-drop file at `~/.openclaw/auto-respawn/.last-mnemonic`
- Agent never sees the recovery phrase — only the file path appears in JSON output
- Human operator retrieves the phrase manually: `chmod 600`, `cat`, back up, `rm`

## Changes
- **`lib/wallet.ts`** — added `writeMnemonicDeadDrop()` (write with 0600, then chmod 000), refactored path constants
- **`auto-respawn.ts`** — replaced stderr mnemonic block with dead-drop call, added `mnemonicPath` and security message to JSON output
- **`SKILL.md`** — updated wallet create docs, local storage section, important notes, and usage examples

## Test plan
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm test` passes (88 tests)
- [ ] Manual: `wallet create` no longer prints mnemonic to stderr
- [ ] Manual: `.last-mnemonic` file created with `000` permissions
- [ ] Manual: `chmod 600 && cat` retrieves the phrase correctly

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)