### PR TITLE
Publish skills to 0xautonomys account on ClawHub

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,6 +70,7 @@ jobs:
             --tags "${{ steps.meta.outputs.tags }}"
 
       - name: Publish to ClawHub (jim-counter — legacy)
+        if: always() && steps.meta.outputs.dir != ''
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,11 +35,15 @@ jobs:
               echo "dir=autonomys/auto-memory" >> "$GITHUB_OUTPUT"
               echo "name=Auto Memory" >> "$GITHUB_OUTPUT"
               echo "tags=memory,persistence,decentralized,autonomys,long-term,openclaw" >> "$GITHUB_OUTPUT"
+              echo "legacy_slug=auto-memory" >> "$GITHUB_OUTPUT"
+              echo "new_slug=permanent-memory" >> "$GITHUB_OUTPUT"
               ;;
             auto-respawn)
               echo "dir=autonomys/auto-respawn" >> "$GITHUB_OUTPUT"
               echo "name=Auto Respawn" >> "$GITHUB_OUTPUT"
               echo "tags=identity,agent-memory,decentralized,autonomys,resurrection,persistence" >> "$GITHUB_OUTPUT"
+              echo "legacy_slug=auto-respawn" >> "$GITHUB_OUTPUT"
+              echo "new_slug=respawn" >> "$GITHUB_OUTPUT"
               ;;
             *)
               echo "Error: Unknown skill '${{ steps.tag.outputs.skill }}'" >&2
@@ -54,13 +58,24 @@ jobs:
             exit 1
           fi
 
-      - name: Publish to ClawHub
+      - name: Publish to ClawHub (0xautonomys — primary)
+        env:
+          CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN_0XAUTONOMYS }}
+        run: |
+          npx clawhub login --token "$CLAWHUB_TOKEN" --no-browser
+          npx clawhub publish "${{ steps.meta.outputs.dir }}" \
+            --slug "${{ steps.meta.outputs.new_slug }}" \
+            --name "${{ steps.meta.outputs.name }}" \
+            --version "${{ steps.tag.outputs.version }}" \
+            --tags "${{ steps.meta.outputs.tags }}"
+
+      - name: Publish to ClawHub (jim-counter — legacy)
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
         run: |
           npx clawhub login --token "$CLAWHUB_TOKEN" --no-browser
           npx clawhub publish "${{ steps.meta.outputs.dir }}" \
-            --slug "${{ steps.tag.outputs.skill }}" \
+            --slug "${{ steps.meta.outputs.legacy_slug }}" \
             --name "${{ steps.meta.outputs.name }}" \
             --version "${{ steps.tag.outputs.version }}" \
             --tags "${{ steps.meta.outputs.tags }}"

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ Each skill lives in its own directory under `autonomys/` with a `SKILL.md` that 
 
 ### auto-memory
 
-[clawhub.ai/jim-counter/auto-memory](https://clawhub.ai/jim-counter/auto-memory)
+[clawhub.ai/0xautonomys/permanent-memory](https://clawhub.ai/0xautonomys/permanent-memory)
 
 ```bash
-npx clawhub install auto-memory
+npx clawhub install permanent-memory
 ```
 
 Permanent decentralized storage via the Autonomys Auto Drive API. Gives your agent:
@@ -33,10 +33,10 @@ auto-memory only needs an Auto Drive API key (free at [ai3.storage](https://ai3.
 
 ### auto-respawn
 
-[clawhub.ai/jim-counter/auto-respawn](https://clawhub.ai/jim-counter/auto-respawn)
+[clawhub.ai/0xautonomys/respawn](https://clawhub.ai/0xautonomys/respawn)
 
 ```bash
-npx clawhub install auto-respawn
+npx clawhub install respawn
 ```
 
 On-chain identity and memory anchoring on the Autonomys Network. Gives your agent:
@@ -81,17 +81,17 @@ Skills are published to [ClawHub](https://docs.openclaw.ai) via `.github/workflo
    - Parses the skill name and version from the tag (strips the `v` prefix — ClawHub expects bare semver like `0.2.0`, not `v0.2.0`)
    - Resolves the skill directory (`autonomys/auto-memory` or `autonomys/auto-respawn`)
    - Validates that `SKILL.md` exists in the directory
-   - Authenticates with ClawHub using the `CLAWHUB_TOKEN` repository secret
-   - Publishes with `npx clawhub publish` including `--tags beta`
+   - Publishes to both ClawHub accounts (primary `0xautonomys` and legacy `jim-counter`)
 
 ### Supported skills
 
-| Tag prefix | Directory | ClawHub slug | Display name |
-|---|---|---|---|
-| `auto-memory/v*` | `autonomys/auto-memory` | `auto-memory` | Auto Memory |
-| `auto-respawn/v*` | `autonomys/auto-respawn` | `auto-respawn` | Auto Respawn |
+| Tag prefix | Directory | Primary slug (0xautonomys) | Legacy slug (jim-counter) | Display name |
+|---|---|---|---|---|
+| `auto-memory/v*` | `autonomys/auto-memory` | `permanent-memory` | `auto-memory` | Auto Memory |
+| `auto-respawn/v*` | `autonomys/auto-respawn` | `respawn` | `auto-respawn` | Auto Respawn |
 
 ### Requirements
 
-- A `CLAWHUB_TOKEN` repository secret must be configured in GitHub
+- `CLAWHUB_TOKEN_0XAUTONOMYS` repository secret — for the primary `0xautonomys` account
+- `CLAWHUB_TOKEN` repository secret — for the legacy `jim-counter` account
 - The tagged commit must contain a valid `SKILL.md` in the skill's directory

--- a/autonomys/auto-respawn/.clawhubignore
+++ b/autonomys/auto-respawn/.clawhubignore
@@ -1,0 +1,2 @@
+tests/
+eslint.config.js


### PR DESCRIPTION
## Summary
- Publish workflow now deploys to both the new `0xautonomys` account (`permanent-memory`, `respawn`) and the legacy `jim-counter` account (`auto-memory`, `auto-respawn`) on each tag push
- README updated with new primary ClawHub URLs and install commands
- Added `.clawhubignore` to auto-respawn to exclude `tests/` and `eslint.config.js` from published bundles

## Test plan
- [x] Verify `CLAWHUB_TOKEN_0XAUTONOMYS` secret is configured in repo settings
- [x] Tag a test release and confirm both publish steps succeed
- [x] Install from the new slug (`npx clawhub install permanent-memory` / `npx clawhub install respawn`) and verify the skill works
- [x] Confirm legacy slugs still install correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)